### PR TITLE
Update get-scal.xml

### DIFF
--- a/src/main/scripts/ctl/get-scal.xml
+++ b/src/main/scripts/ctl/get-scal.xml
@@ -502,7 +502,7 @@
 											</wcs:CoverageId>
 											<wcs:Extension>
 												<scal:ScaleByFactor>
-													<scal:scaleFactor>2.0</scal:scaleFactor>
+													<scal:scaleFactor>0.5</scal:scaleFactor>
 												</scal:ScaleByFactor>
 											</wcs:Extension>
 										</wcs:GetCoverage>


### PR DESCRIPTION
spec 12-039 says A value of 1.0 leaves the coverage unscaled, a value between 0 and 1 scales down (reduces target domain), a value greater than 1 scales up (enlarges target domain).
this change correct an issues when the expected value is the original size div 2.
this fix this issue https://github.com/opengeospatial/ets-wcs20/issues/70